### PR TITLE
Enable dark mode by default for new users

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import { HashRouter } from 'react-router-dom';
 import './App.css';
 
 function App() {
-  const [isDark, setIsDark] = useState(localStorage.getItem('__isDark') === 'true');
+  const [isDark, setIsDark] = useState(localStorage.getItem('__isDark') !== null ? localStorage.getItem('__isDark') === 'true' : true);
   const theme = isDark ? ' solarized-dark' : '';
 
   useEffect(() => {


### PR DESCRIPTION
When no localStorage preference exists, default to dark mode instead of light mode.

https://claude.ai/code/session_01DAYBWYpfcpf6HXJ6RmqHnz