### PR TITLE
enhance mobile experience with 7 UX improvements

### DIFF
--- a/src/components/AwesomeRwdMenu/AwesomeRwdMenu.jsx
+++ b/src/components/AwesomeRwdMenu/AwesomeRwdMenu.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faHome } from '@fortawesome/free-solid-svg-icons';
@@ -6,6 +6,25 @@ import { MdDarkMode, MdLightMode } from 'react-icons/md';
 import classes from './AwesomeRwdMenu.module.css';
 
 const AwesomeRwdMenu = ({ topics, topicOnClickHandler, isOpen, onClose, isDark, onThemeChange }) => {
+  const touchStartX = useRef(null);
+  const touchStartY = useRef(null);
+
+  const handleTouchStart = (e) => {
+    touchStartX.current = e.touches[0].clientX;
+    touchStartY.current = e.touches[0].clientY;
+  };
+
+  const handleTouchEnd = (e) => {
+    if (touchStartX.current === null) return;
+    const deltaX = e.changedTouches[0].clientX - touchStartX.current;
+    const deltaY = Math.abs(e.changedTouches[0].clientY - touchStartY.current);
+    if (deltaX > 40 && deltaY < 30) {
+      onClose();
+    }
+    touchStartX.current = null;
+    touchStartY.current = null;
+  };
+
   return (
     <>
       <div
@@ -18,6 +37,8 @@ const AwesomeRwdMenu = ({ topics, topicOnClickHandler, isOpen, onClose, isDark, 
         className={`menu ${classes.AwesomeRwdMenu} ${isOpen ? classes.open : ''}`}
         aria-label="Categories menu"
         data-testid="rwd-menu"
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
       >
         <div className={classes.MenuTop} data-testid="rwd-menu-top">
           <Link

--- a/src/components/AwesomeRwdMenu/AwesomeRwdMenu.module.css
+++ b/src/components/AwesomeRwdMenu/AwesomeRwdMenu.module.css
@@ -19,7 +19,7 @@
     z-index: 998;
     opacity: 0;
     visibility: hidden;
-    transition: none;
+    transition: opacity 0.25s ease, visibility 0.25s ease;
     backdrop-filter: blur(4px);
     -webkit-backdrop-filter: blur(4px);
   }
@@ -42,7 +42,7 @@
     padding: 20px 0;
     overflow-y: auto;
     box-shadow: -8px 0 30px rgba(0, 0, 0, 0.12);
-    transition: none;
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
   .AwesomeRwdMenu.open {

--- a/src/containers/AwesomeReadme/AwesomeReadme.jsx
+++ b/src/containers/AwesomeReadme/AwesomeReadme.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
 import classes from './AwesomeReadme.module.css';
 import TimeAgo from 'timeago-react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -406,6 +407,14 @@ class AwesomeReadme extends Component {
                 {this.props.match.params.repo}
               </span>
               <div className={classes.ReadmeInfoActions}>
+                <Link
+                  className={classes.BackButton}
+                  to="/"
+                  aria-label="Back to list"
+                  data-testid="readme-back-button"
+                >
+                  ← Back
+                </Link>
                 <a
                   className={classes.ViewOnGithubBtn}
                   href={`https://github.com/${this.props.match.params.user}/${this.props.match.params.repo}`}

--- a/src/containers/AwesomeReadme/AwesomeReadme.module.css
+++ b/src/containers/AwesomeReadme/AwesomeReadme.module.css
@@ -61,6 +61,10 @@
   flex-shrink: 0;
 }
 
+a.BackButton {
+  display: none;
+}
+
 a.ViewOnGithubBtn {
   border-bottom: 0;
   display: inline-flex;
@@ -213,7 +217,10 @@ a.ViewOnGithubBtn:hover {
 
 .TocLevel1:hover,
 .TocLevel2:hover,
-.TocLevel3:hover {
+.TocLevel3:hover,
+.TocLevel1:active,
+.TocLevel2:active,
+.TocLevel3:active {
   background: var(--bg-tertiary);
   color: var(--primary);
   border-left-color: var(--primary);
@@ -250,8 +257,14 @@ a.ViewOnGithubBtn:hover {
 .ReadmeContent {
   line-height: 1.7;
   font-size: 15px;
-  overflow-x: hidden;
   word-break: break-word;
+}
+
+.ReadmeContent pre,
+.ReadmeContent code {
+  overflow-x: auto;
+  word-break: normal;
+  white-space: pre;
 }
 
 .ReadmeContent h1,
@@ -375,6 +388,23 @@ a.ViewOnGithubBtn:hover {
     font-size: 15px;
   }
 
+  a.BackButton {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 5px 12px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-secondary) !important;
+    text-decoration: none;
+    border-bottom: none !important;
+    white-space: nowrap;
+  }
+
+  a.BackButton:active {
+    opacity: 0.7;
+  }
+
   a.ViewOnGithubBtn {
     padding: 5px 12px;
     font-size: 12px;
@@ -403,6 +433,15 @@ a.ViewOnGithubBtn:hover {
     padding: 7px 12px;
     font-size: 13px;
   }
+
+  .LightboxContent {
+    max-width: 95vw;
+  }
+
+  .LightboxClose {
+    top: 8px;
+    right: 8px;
+  }
 }
 
 /* ── Dark mode ── */
@@ -413,6 +452,10 @@ a.ViewOnGithubBtn:hover {
 
 :global(.dark) .RepoName {
   color: var(--dark-text-primary);
+}
+
+:global(.dark) a.BackButton {
+  color: var(--dark-text-secondary) !important;
 }
 
 :global(.dark) a.ViewOnGithubBtn {
@@ -470,7 +513,10 @@ a.ViewOnGithubBtn:hover {
 
 :global(.dark) .TocLevel1:hover,
 :global(.dark) .TocLevel2:hover,
-:global(.dark) .TocLevel3:hover {
+:global(.dark) .TocLevel3:hover,
+:global(.dark) .TocLevel1:active,
+:global(.dark) .TocLevel2:active,
+:global(.dark) .TocLevel3:active {
   background: var(--dark-bg-secondary);
   color: var(--dark-primary);
   border-left-color: var(--dark-primary);

--- a/src/containers/AwesomeSearch/AwesomeSearch.jsx
+++ b/src/containers/AwesomeSearch/AwesomeSearch.jsx
@@ -76,8 +76,15 @@ class AwesomeSearch extends Component {
         window.addEventListener('resize', this.updateHeaderHeight);
     }
 
+    componentDidUpdate(_, prevState) {
+        if (prevState.showMenu !== this.state.showMenu) {
+            document.body.style.overflow = this.state.showMenu ? 'hidden' : '';
+        }
+    }
+
     componentWillUnmount() {
         window.removeEventListener('resize', this.updateHeaderHeight);
+        document.body.style.overflow = '';
     }
 
     updateHeaderHeight = () => {


### PR DESCRIPTION
- Smooth menu animation: replace transition:none with proper CSS transitions
  for overlay fade (0.25s) and panel slide-in (0.3s cubic-bezier)
- Body scroll lock: add componentDidUpdate to AwesomeSearch to set
  document.body.style.overflow when mobile menu opens/closes
- Swipe-to-close: add touch event handlers (useRef) to AwesomeRwdMenu
  with 40px horizontal threshold and 30px vertical drift guard
- README code block overflow: remove overflow-x:hidden from ReadmeContent,
  add overflow-x:auto + white-space:pre on pre/code for horizontal scroll
- Lightbox close button: reposition to top:8px right:8px on mobile so it
  stays within the viewport on small screens (was top:-16px right:-16px)
- TOC touch feedback: add :active states matching :hover for TocLevel1/2/3
  (light + dark mode) so taps show visual feedback on mobile
- Back button in README info bar: add a mobile-only "← Back" Link to the
  fixed bottom bar in AwesomeReadme for quick navigation back to list

https://claude.ai/code/session_01CHyFHL8uCnfpyVPhvye49P