### PR TITLE
Fix clipped text in mobile search result rows

### DIFF
--- a/src/components/AwesomeInput/AwesomeInput.module.css
+++ b/src/components/AwesomeInput/AwesomeInput.module.css
@@ -164,6 +164,7 @@
   transition: background 80ms, border-color 80ms;
   min-width: 0;
   overflow: hidden;
+  isolation: isolate;
 }
 
 .ResultRow::after {
@@ -179,6 +180,13 @@
   mask-composite: exclude;
   opacity: 0;
   pointer-events: none;
+  z-index: 0;
+}
+
+/* Keep text content above the decorative border layer on mobile WebKit. */
+.ResultRow > * {
+  position: relative;
+  z-index: 1;
 }
 
 .ResultRow:hover,
@@ -207,6 +215,7 @@
   font-family: 'Space Grotesk', system-ui, sans-serif;
   font-size: 14px;
   font-weight: 600;
+  line-height: 1.35;
   letter-spacing: -0.2px;
   color: var(--fg);
   overflow: hidden;
@@ -217,6 +226,7 @@
 .RepoPath {
   color: var(--dim);
   font-size: 11px;
+  line-height: 1.35;
   font-family: 'JetBrains Mono', monospace;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
### Motivation

- Mobile WebKit was rendering decorative border pseudo-elements above card text which caused glyph clipping in search result rows.

### Description

- Updated `src/components/AwesomeInput/AwesomeInput.module.css` to force the decorative border pseudo-element behind content by setting `z-index: 0` on `::after` and `isolation: isolate` on `.ResultRow`.
- Ensured content stays above the decorative layer by adding `position: relative; z-index: 1` to direct children of `.ResultRow`.
- Added explicit `line-height: 1.35` to `.RepoName` and `.RepoPath` to avoid glyph ascenders/descenders being cut on some mobile browsers.
- Visual appearance and desktop behavior of the result cards are preserved while improving readability on mobile.

### Testing

- Ran unit tests for the input component with `npm run test -- src/components/AwesomeInput/AwesomeInput.test.jsx` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edfba0c2a08324abc12bda782b8e27)