### PR TITLE
Fix mobile search input text clipping

### DIFF
--- a/src/components/AwesomeInput/AwesomeInput.module.css
+++ b/src/components/AwesomeInput/AwesomeInput.module.css
@@ -55,9 +55,12 @@
   font-family: 'Space Grotesk', system-ui, sans-serif;
   font-size: 22px;
   font-weight: 500;
+  /* Keep glyph ascenders/descenders visible on mobile WebKit/Chrome. */
+  line-height: 1.25;
   color: var(--fg);
   letter-spacing: -0.3px;
-  padding: 0;
+  padding: 2px 0;
+  min-height: calc(1em * 1.25);
   min-width: 0;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent input text glyphs (ascenders/descenders) from being visually clipped on mobile WebKit/Chrome when typing in the search box.

### Description
- Add an explicit `line-height`, small vertical `padding`, and a `min-height` derived from the line-height to `src/components/AwesomeInput/AwesomeInput.module.css` so the search input content renders without clipping.

### Testing
- Ran the unit test suite with `npm test` (Vitest) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee020881148324a1bbb5fbb2cab0c7)