### PR TITLE
Adjust search result rows to fit content

### DIFF
--- a/src/components/AwesomeInput/AwesomeInput.module.css
+++ b/src/components/AwesomeInput/AwesomeInput.module.css
@@ -147,6 +147,7 @@
   overflow: auto;
   display: grid;
   grid-template-columns: 1fr 1fr;
+  align-items: start;
   align-content: start;
   border-top: 1px solid var(--line-dim);
   padding: 12px 20px;


### PR DESCRIPTION
### Motivation
- Ensure each search result card sizes to its own content instead of stretching to match the tallest item in the grid.

### Description
- Add `align-items: start` to `.ResultList` in `src/components/AwesomeInput/AwesomeInput.module.css` so grid items maintain natural heights.

### Testing
- Ran `npm test -- src/components/AwesomeInput/AwesomeInput.test.jsx` and all tests passed (1 file, 5 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0601a510832488f71b3266380100)