### PR TITLE
Align result cards to top in AwesomeInput grid

### DIFF
--- a/src/components/AwesomeInput/AwesomeInput.module.css
+++ b/src/components/AwesomeInput/AwesomeInput.module.css
@@ -147,6 +147,7 @@
   overflow: auto;
   display: grid;
   grid-template-columns: 1fr 1fr;
+  align-items: start;
   align-content: start;
   border-top: 1px solid var(--line-dim);
   padding: 12px 20px;
@@ -157,6 +158,8 @@
 .ResultRow {
   display: flex;
   flex-direction: column;
+  align-self: start;
+  height: auto;
   gap: 4px;
   padding: 12px 14px;
   background: var(--bg-panel);


### PR DESCRIPTION
### Motivation
- Prevent result cards in the two-column grid from vertically stretching or centering so each card aligns to the top of its grid cell for consistent layout.

### Description
- Added `align-items: start` to `.ResultList` and added `align-self: start` and `height: auto` to `.ResultRow` to ensure cards are positioned at the top and not stretched to match column heights.

### Testing
- Ran the project's automated test suite with `npm test`, the linter with `npm run lint`, and a production build with `npm run build`, and all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0601a510832488f71b3266380100)