### PR TITLE
Top-align result cards and prevent clipping in AwesomeInput result grid

### DIFF
--- a/src/components/AwesomeInput/AwesomeInput.module.css
+++ b/src/components/AwesomeInput/AwesomeInput.module.css
@@ -147,6 +147,7 @@
   overflow: auto;
   display: grid;
   grid-template-columns: 1fr 1fr;
+  align-items: start;
   align-content: start;
   border-top: 1px solid var(--line-dim);
   padding: 12px 20px;
@@ -157,6 +158,8 @@
 .ResultRow {
   display: flex;
   flex-direction: column;
+  align-self: start;
+  height: auto;
   gap: 4px;
   padding: 12px 14px;
   background: var(--bg-panel);
@@ -166,7 +169,6 @@
   cursor: pointer;
   transition: background 80ms, border-color 80ms;
   min-width: 0;
-  overflow: hidden;
   isolation: isolate;
 }
 


### PR DESCRIPTION
### Motivation
- Fix vertical alignment and content clipping of result cards in the two-column grid so cards align to the top and size naturally across breakpoints.

### Description
- Added `align-items: start` to `.ResultList` to top-align grid rows.
- Set `.ResultRow` to `align-self: start` and `height: auto` to avoid stretching and allow proper card sizing.
- Removed `overflow: hidden` from `.ResultRow` to prevent child content from being clipped.
- Preserved the decorative pseudo-element and stacking context so border visuals remain unchanged.

### Testing
- Ran unit tests with `yarn test` and they passed.
- Ran the linter with `yarn lint` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee0601a510832488f71b3266380100)