### PR TITLE
Avoid auto-focusing search input after category selection

### DIFF
--- a/src/components/AwesomeInput/AwesomeInput.jsx
+++ b/src/components/AwesomeInput/AwesomeInput.jsx
@@ -54,7 +54,14 @@ function Highlight({ text, query }) {
   return <>{out}</>;
 }
 
-const AwesomeInput = ({ query, setQuery, results, onOpen, onClear }) => {
+const AwesomeInput = ({
+  query,
+  setQuery,
+  results,
+  onOpen,
+  onClear,
+  autoFocus = true,
+}) => {
   const [selected, setSelected] = useState(0);
   const inputRef = useRef(null);
   const listRef = useRef(null);
@@ -64,8 +71,9 @@ const AwesomeInput = ({ query, setQuery, results, onOpen, onClear }) => {
   }, [results]);
 
   useEffect(() => {
+    if (!autoFocus) return;
     inputRef.current?.focus();
-  }, []);
+  }, [autoFocus]);
 
   // Scroll selected into view
   useEffect(() => {

--- a/src/components/AwesomeInput/AwesomeInput.test.jsx
+++ b/src/components/AwesomeInput/AwesomeInput.test.jsx
@@ -58,4 +58,9 @@ describe('AwesomeInput (SearchView)', () => {
     fireEvent.click(screen.getByTestId('search-result-item'));
     expect(defaultProps.onOpen).toHaveBeenCalledWith('sindresorhus/awesome-react');
   });
+
+  it('does not auto-focus input when autoFocus is false', () => {
+    renderWithRouter(<AwesomeInput {...defaultProps} autoFocus={false} />);
+    expect(screen.getByTestId('search-input')).not.toHaveFocus();
+  });
 });

--- a/src/containers/AwesomeSearch/AwesomeSearch.jsx
+++ b/src/containers/AwesomeSearch/AwesomeSearch.jsx
@@ -16,6 +16,7 @@ class AwesomeSearch extends Component {
     search: '',
     searchResult: [],
     errorMessage: null,
+    shouldAutoFocusSearchInput: true,
   };
 
   componentDidMount() {
@@ -48,14 +49,22 @@ class AwesomeSearch extends Component {
   handleSearch = (value) => {
     if (!this.fuse) return;
     const results = this.fuse.search(value).slice(0, 20);
-    this.setState({ search: value, searchResult: results });
+    this.setState({
+      search: value,
+      searchResult: results,
+      shouldAutoFocusSearchInput: true,
+    });
   };
 
   handleCategoryFilter = (categoryName) => {
     const results = this.state.subjectsArray
       .filter((item) => item.cate === categoryName)
       .map((item) => ({ item, score: 0, refIndex: 0 }));
-    this.setState({ search: categoryName, searchResult: results });
+    this.setState({
+      search: categoryName,
+      searchResult: results,
+      shouldAutoFocusSearchInput: false,
+    });
   };
 
   handleOpen = (repo) => {
@@ -87,7 +96,13 @@ class AwesomeSearch extends Component {
   };
 
   render() {
-    const { search, searchResult, subjects, subjectsArray } = this.state;
+    const {
+      search,
+      searchResult,
+      subjects,
+      subjectsArray,
+      shouldAutoFocusSearchInput,
+    } = this.state;
     const { location } = this.props;
     const isHome = location.pathname === '/';
     const isSearchActive = isHome && search.trim().length >= 2;
@@ -124,6 +139,7 @@ class AwesomeSearch extends Component {
                       results={searchResult}
                       onOpen={this.handleOpen}
                       onClear={() => this.setState({ search: '' })}
+                      autoFocus={shouldAutoFocusSearchInput}
                     />
                   ) : (
                     <AwesomeHome

--- a/src/containers/AwesomeSearch/AwesomeSearch.test.jsx
+++ b/src/containers/AwesomeSearch/AwesomeSearch.test.jsx
@@ -124,4 +124,20 @@ describe('AwesomeSearch', () => {
 
     expect(screen.queryAllByTestId('search-result-link')).toHaveLength(0);
   });
+
+  it('does not auto-focus search input after clicking a category', async () => {
+    axios.get.mockResolvedValue({ data: mockSubjects });
+    render(
+      <MemoryRouter>
+        <AwesomeSearch />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /Front-End/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search-results')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('search-input')).not.toHaveFocus();
+  });
 });


### PR DESCRIPTION
### Motivation
- Prevent the search input from stealing focus when the user navigates to a category (category-click flow), while preserving the existing autofocus behavior for typed searches and other keyboard-first interactions.

### Description
- Add an `autoFocus` prop (default `true`) to `AwesomeInput` and gate the mount-time focus effect so the parent can disable autofocus when needed.
- Introduce `shouldAutoFocusSearchInput` in `AwesomeSearch` state and set it to `true` for typed searches and `false` when a category is selected.
- Pass `shouldAutoFocusSearchInput` into `AwesomeInput` to control whether the input receives focus on render.
- Add tests to assert that `AwesomeInput` does not focus when `autoFocus={false}` and that clicking a category in `AwesomeSearch` shows results without focusing the input.

### Testing
- Ran the targeted unit tests: `npm test -- src/components/AwesomeInput/AwesomeInput.test.jsx src/containers/AwesomeSearch/AwesomeSearch.test.jsx` and all tests passed (`Test Files 2 passed, Tests 14 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee114ead248324baddc20758c2b4a2)