### PR TITLE
Add README scroll percentage indicator

### DIFF
--- a/src/containers/AwesomeReadme/AwesomeReadme.jsx
+++ b/src/containers/AwesomeReadme/AwesomeReadme.jsx
@@ -14,6 +14,7 @@ class AwesomeReadme extends Component {
     activeSection: null,
     previewSrc: null,
     sidebarWidth: 240,
+    scrollPercent: 0,
   };
 
   contentRef = React.createRef();
@@ -31,6 +32,7 @@ class AwesomeReadme extends Component {
     if (prevState._html !== this.state._html) {
       this.makeAnchor();
       this.attachImageHandlers();
+      this.updateScrollProgress();
       if (this.state.headers.length > 0) {
         this.setState({ activeSection: this.state.headers[0].id });
       }
@@ -235,6 +237,7 @@ class AwesomeReadme extends Component {
 
   handleContentScroll = () => {
     if (!this.contentRef.current) return;
+    this.updateScrollProgress();
     const headers = this.contentRef.current.querySelectorAll('[data-testid="readme-content"] [id]');
     const containerTop = this.contentRef.current.getBoundingClientRect().top;
     let cur = this.state.headers[0]?.id;
@@ -244,9 +247,23 @@ class AwesomeReadme extends Component {
     if (cur && cur !== this.state.activeSection) this.setState({ activeSection: cur });
   };
 
+  updateScrollProgress = () => {
+    const contentEl = this.contentRef.current;
+    if (!contentEl) return;
+
+    const maxScrollableDistance = contentEl.scrollHeight - contentEl.clientHeight;
+    const nextPercent = maxScrollableDistance <= 0
+      ? 100
+      : Math.min(100, Math.round((contentEl.scrollTop / maxScrollableDistance) * 100));
+
+    if (nextPercent !== this.state.scrollPercent) {
+      this.setState({ scrollPercent: nextPercent });
+    }
+  };
+
   render() {
     const { user, repo } = this.props.match.params;
-    const { _html, isLoading, headers, stars, updateAt, activeSection, previewSrc, sidebarWidth } = this.state;
+    const { _html, isLoading, headers, stars, updateAt, activeSection, previewSrc, sidebarWidth, scrollPercent } = this.state;
 
     const fmtStars = stars >= 1000 ? `${(stars / 1000).toFixed(1)}k` : `${stars || '—'}`;
 
@@ -355,6 +372,10 @@ class AwesomeReadme extends Component {
               data-testid="readme-content"
             />
           )}
+
+          <div className={classes.ScrollProgress} data-testid="readme-scroll-progress">
+            Scrolled: {scrollPercent}%
+          </div>
         </div>
 
         {/* Lightbox */}

--- a/src/containers/AwesomeReadme/AwesomeReadme.module.css
+++ b/src/containers/AwesomeReadme/AwesomeReadme.module.css
@@ -121,6 +121,22 @@
   padding: 30px 34px;
 }
 
+.ScrollProgress {
+  position: sticky;
+  bottom: 0;
+  margin-top: 20px;
+  padding: 8px 12px;
+  margin-left: auto;
+  width: fit-content;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: color-mix(in oklab, var(--bg-panel) 92%, transparent);
+  color: var(--mid);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
 .RepoLabel {
   font-family: 'Space Grotesk', system-ui, sans-serif;
   font-size: 11px;

--- a/src/containers/AwesomeReadme/AwesomeReadme.test.jsx
+++ b/src/containers/AwesomeReadme/AwesomeReadme.test.jsx
@@ -56,4 +56,10 @@ describe('AwesomeReadme', () => {
     renderReadme();
     expect(screen.getByText('awesome-nodejs')).toBeInTheDocument();
   });
+
+  it('shows scroll progress label at the bottom area', () => {
+    axios.get.mockReturnValue(new Promise(() => {}));
+    renderReadme();
+    expect(screen.getByTestId('readme-scroll-progress')).toHaveTextContent('Scrolled: 0%');
+  });
 });


### PR DESCRIPTION
### Motivation
- Provide users with feedback about how far they've scrolled in the README markdown view so they know their reading progress.

### Description
- Add `scrollPercent` to `AwesomeReadme` state and compute it from the content container's `scrollTop` versus `scrollHeight` in a new `updateScrollProgress` helper that is invoked on content load and on scroll.
- Call `updateScrollProgress` when the README HTML is injected and from the existing `handleContentScroll` so the value stays in sync while scrolling.
- Render a persistent bottom label inside the content area showing `Scrolled: N%` and add `.ScrollProgress` styles to keep the badge visible and themed with the app. 
- Add a unit test that asserts the progress label is present with an initial `0%` value.

### Testing
- Ran the unit test file with `npm test -- src/containers/AwesomeReadme/AwesomeReadme.test.jsx`, which executed the test suite and reported all tests passed (5 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee155c2bdc8324b7d6fe2b23b44183)