### PR TITLE
Expose README scroll progress and show percent in footer

### DIFF
--- a/src/containers/AwesomeReadme/AwesomeReadme.jsx
+++ b/src/containers/AwesomeReadme/AwesomeReadme.jsx
@@ -14,6 +14,7 @@ class AwesomeReadme extends Component {
     activeSection: null,
     previewSrc: null,
     sidebarWidth: 240,
+    scrollPercent: 0,
   };
 
   contentRef = React.createRef();
@@ -31,6 +32,7 @@ class AwesomeReadme extends Component {
     if (prevState._html !== this.state._html) {
       this.makeAnchor();
       this.attachImageHandlers();
+      this.updateScrollProgress();
       if (this.state.headers.length > 0) {
         this.setState({ activeSection: this.state.headers[0].id });
       }
@@ -40,6 +42,7 @@ class AwesomeReadme extends Component {
   componentWillUnmount() {
     window.removeEventListener('keydown', this.handleKeyDown);
     this._stopDrag();
+    this.props.onScrollPercentChange?.(null);
   }
 
   _onResizeMouseDown = (e) => {
@@ -235,6 +238,7 @@ class AwesomeReadme extends Component {
 
   handleContentScroll = () => {
     if (!this.contentRef.current) return;
+    this.updateScrollProgress();
     const headers = this.contentRef.current.querySelectorAll('[data-testid="readme-content"] [id]');
     const containerTop = this.contentRef.current.getBoundingClientRect().top;
     let cur = this.state.headers[0]?.id;
@@ -242,6 +246,21 @@ class AwesomeReadme extends Component {
       if (h.getBoundingClientRect().top - containerTop < 100) cur = h.id;
     }
     if (cur && cur !== this.state.activeSection) this.setState({ activeSection: cur });
+  };
+
+  updateScrollProgress = () => {
+    const contentEl = this.contentRef.current;
+    if (!contentEl) return;
+
+    const maxScrollableDistance = contentEl.scrollHeight - contentEl.clientHeight;
+    const nextPercent = maxScrollableDistance <= 0
+      ? 100
+      : Math.min(100, Math.round((contentEl.scrollTop / maxScrollableDistance) * 100));
+
+    if (nextPercent !== this.state.scrollPercent) {
+      this.setState({ scrollPercent: nextPercent });
+      this.props.onScrollPercentChange?.(nextPercent);
+    }
   };
 
   render() {
@@ -299,62 +318,62 @@ class AwesomeReadme extends Component {
           onScroll={this.handleContentScroll}
           className={classes.ContentArea}
         >
-          {/* Breadcrumb label */}
-          <div className={classes.RepoLabel}>README.md · {user}/{repo}</div>
-          <h1 className={classes.RepoTitle}>{repo}</h1>
+            {/* Breadcrumb label */}
+            <div className={classes.RepoLabel}>README.md · {user}/{repo}</div>
+            <h1 className={classes.RepoTitle}>{repo}</h1>
 
-          {/* Stats panel */}
-          {this.state.showReadmeInfo && (
-            <div className={classes.StatsPanel} data-testid="repo-stats">
-              {[
-                ['Stars', fmtStars, true],
-                ['Updated', updateAt ? <TimeAgo datetime={updateAt} /> : '—', false],
-                ['Owner', user, false],
-                [
-                  'GitHub',
-                  <a
-                    href={`https://github.com/${user}/${repo}`}
-                    target="_blank"
-                    rel="noreferrer"
-                    data-testid="view-on-github"
+            {/* Stats panel */}
+            {this.state.showReadmeInfo && (
+              <div className={classes.StatsPanel} data-testid="repo-stats">
+                {[
+                  ['Stars', fmtStars, true],
+                  ['Updated', updateAt ? <TimeAgo datetime={updateAt} /> : '—', false],
+                  ['Owner', user, false],
+                  [
+                    'GitHub',
+                    <a
+                      href={`https://github.com/${user}/${repo}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      data-testid="view-on-github"
+                    >
+                      View ↗
+                    </a>,
+                    false,
+                  ],
+                ].map(([k, v, accent], i) => (
+                  <div
+                    key={i}
+                    className={classes.StatCell}
+                    style={{ borderLeft: i === 0 ? 'none' : undefined }}
                   >
-                    View ↗
-                  </a>,
-                  false,
-                ],
-              ].map(([k, v, accent], i) => (
-                <div
-                  key={i}
-                  className={classes.StatCell}
-                  style={{ borderLeft: i === 0 ? 'none' : undefined }}
-                >
-                  <div className={classes.StatKey}>{k}</div>
-                  <div className={`${classes.StatVal} ${accent ? classes.StatValAccent : ''}`}>
-                    {v}
+                    <div className={classes.StatKey}>{k}</div>
+                    <div className={`${classes.StatVal} ${accent ? classes.StatValAccent : ''}`}>
+                      {v}
+                    </div>
                   </div>
-                </div>
-              ))}
-            </div>
-          )}
+                ))}
+              </div>
+            )}
 
-          {/* Skeleton */}
-          {isLoading ? (
-            <div className={classes.Skeleton} data-testid="readme-skeleton">
-              {[100, 80, 90, 60, 100, 75, 85, 55].map((w, i) => (
-                <div
-                  key={i}
-                  className={classes.SkeletonLine}
-                  style={{ width: `${w}%`, height: i % 4 === 0 ? 18 : 12, marginTop: i % 4 === 0 ? 20 : 8 }}
-                />
-              ))}
-            </div>
-          ) : (
-            <div
-              className={classes.ReadmeContent}
-              dangerouslySetInnerHTML={{ __html: _html }}
-              data-testid="readme-content"
-            />
-          )}
+            {/* Skeleton */}
+            {isLoading ? (
+              <div className={classes.Skeleton} data-testid="readme-skeleton">
+                {[100, 80, 90, 60, 100, 75, 85, 55].map((w, i) => (
+                  <div
+                    key={i}
+                    className={classes.SkeletonLine}
+                    style={{ width: `${w}%`, height: i % 4 === 0 ? 18 : 12, marginTop: i % 4 === 0 ? 20 : 8 }}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div
+                className={classes.ReadmeContent}
+                dangerouslySetInnerHTML={{ __html: _html }}
+                data-testid="readme-content"
+              />
+            )}
         </div>
 
         {/* Lightbox */}

--- a/src/containers/AwesomeReadme/AwesomeReadme.test.jsx
+++ b/src/containers/AwesomeReadme/AwesomeReadme.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route } from 'react-router-dom';
 import { vi } from 'vitest';
 import AwesomeReadme from './AwesomeReadme.jsx';

--- a/src/containers/AwesomeSearch/AwesomeSearch.jsx
+++ b/src/containers/AwesomeSearch/AwesomeSearch.jsx
@@ -17,6 +17,7 @@ class AwesomeSearch extends Component {
     searchResult: [],
     errorMessage: null,
     shouldAutoFocusSearchInput: true,
+    readmeScrollPercent: null,
   };
 
   componentDidMount() {
@@ -73,8 +74,12 @@ class AwesomeSearch extends Component {
   };
 
   goHome = () => {
-    this.setState({ search: '' });
+    this.setState({ search: '', readmeScrollPercent: null });
     this.props.history.push('/');
+  };
+
+  handleReadmeScrollPercent = (value) => {
+    this.setState({ readmeScrollPercent: value });
   };
 
   handleSiteMapNavigate = (type, value) => {
@@ -102,6 +107,7 @@ class AwesomeSearch extends Component {
       subjects,
       subjectsArray,
       shouldAutoFocusSearchInput,
+      readmeScrollPercent,
     } = this.state;
     const { location } = this.props;
     const isHome = location.pathname === '/';
@@ -160,6 +166,7 @@ class AwesomeSearch extends Component {
                     key={`${props.match.params.user}/${props.match.params.repo}`}
                     {...props}
                     onBack={this.goHome}
+                    onScrollPercentChange={this.handleReadmeScrollPercent}
                   />
                 )}
               />
@@ -196,6 +203,12 @@ class AwesomeSearch extends Component {
                 <span>readme</span>
                 <span className={classes.FooterSep}>·</span>
                 <span>markdown</span>
+                {typeof readmeScrollPercent === 'number' && (
+                  <>
+                    <span className={classes.FooterSep}>·</span>
+                    <span data-testid="readme-scroll-progress">{readmeScrollPercent}%</span>
+                  </>
+                )}
               </>
             )}
           />


### PR DESCRIPTION
### Motivation
- Provide feedback about how far the user has scrolled through a README and expose that progress to parent components so the UI (footer) can display it.

### Description
- Add `scrollPercent` state and `updateScrollProgress` helper in `AwesomeReadme` to compute and track scroll progress as a percentage and call `onScrollPercentChange` whenever it changes.
- Invoke `updateScrollProgress` after content is rendered and on content scroll, and notify parent with `null` on unmount to clear the value.
- Wire `onScrollPercentChange` into `AwesomeSearch` by adding `readmeScrollPercent` state and `handleReadmeScrollPercent`, pass the handler to `AwesomeReadme`, reset it on `goHome`, and render the percent in the footer when available.
- Tidy test imports in `AwesomeReadme.test.jsx` by removing an unused `waitFor` import.

### Testing
- Ran the component unit tests with Vitest and React Testing Library after the change, and the test suite passed with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee155c2bdc8324b7d6fe2b23b44183)