### PR TITLE
Shrink search header when user scrolls results

### DIFF
--- a/src/components/AwesomeInput/AwesomeInput.jsx
+++ b/src/components/AwesomeInput/AwesomeInput.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { withRouter } from 'react-router-dom';
 import classes from './AwesomeInput.module.css';
 
@@ -63,8 +63,13 @@ const AwesomeInput = ({
   autoFocus = true,
 }) => {
   const [selected, setSelected] = useState(0);
+  const [scrolled, setScrolled] = useState(false);
   const inputRef = useRef(null);
   const listRef = useRef(null);
+
+  const handleResultsScroll = useCallback((e) => {
+    setScrolled(e.currentTarget.scrollTop > 40);
+  }, []);
 
   useEffect(() => {
     setSelected(0);
@@ -106,7 +111,7 @@ const AwesomeInput = ({
   return (
     <div className={classes.SearchView}>
       {/* Input row */}
-      <div className={classes.InputSection}>
+      <div className={`${classes.InputSection} ${scrolled ? classes.InputSectionScrolled : ''}`}>
         <div className={classes.SubLabel}>
           Fuzzy search · {query ? `${results.length} matches` : 'type to search'}
         </div>
@@ -159,7 +164,7 @@ const AwesomeInput = ({
       )}
 
       {hasResults && (
-        <div ref={listRef} className={classes.ResultList} data-testid="search-results">
+        <div ref={listRef} className={classes.ResultList} onScroll={handleResultsScroll} data-testid="search-results">
           {results.map((r, idx) => {
             const isSel = idx === selected;
             return (

--- a/src/components/AwesomeInput/AwesomeInput.module.css
+++ b/src/components/AwesomeInput/AwesomeInput.module.css
@@ -12,6 +12,11 @@
 .InputSection {
   padding: 28px 30px 16px;
   flex-shrink: 0;
+  transition: padding 220ms ease;
+}
+
+.InputSectionScrolled {
+  padding: 10px 30px 10px;
 }
 
 .SubLabel {
@@ -22,6 +27,16 @@
   color: var(--amber);
   text-transform: uppercase;
   margin-bottom: 8px;
+  overflow: hidden;
+  max-height: 30px;
+  opacity: 1;
+  transition: max-height 220ms ease, margin-bottom 220ms ease, opacity 180ms ease;
+}
+
+.InputSectionScrolled .SubLabel {
+  max-height: 0;
+  margin-bottom: 0;
+  opacity: 0;
 }
 
 .InputBox {
@@ -94,6 +109,16 @@
   align-items: center;
   flex-wrap: wrap;
   font-family: 'JetBrains Mono', monospace;
+  overflow: hidden;
+  max-height: 60px;
+  opacity: 1;
+  transition: max-height 220ms ease, margin-top 220ms ease, opacity 180ms ease;
+}
+
+.InputSectionScrolled .Hints {
+  max-height: 0;
+  margin-top: 0;
+  opacity: 0;
 }
 
 .Hints span { display: inline-flex; align-items: center; gap: 5px; }
@@ -268,6 +293,7 @@
 /* Responsive */
 @media (max-width: 768px) {
   .InputSection { padding: 56px 16px 16px; }
+  .InputSectionScrolled { padding: 12px 16px 8px; }
   .ResultList {
     grid-template-columns: 1fr;
     padding: 8px 12px;


### PR DESCRIPTION
Listens to scroll events on the ResultList and collapses the SubLabel
and Hints rows (with smooth CSS transitions) while reducing padding on
the InputSection, giving more vertical space to view results. Restores
automatically when the user scrolls back to the top.

https://claude.ai/code/session_01Y4RTjMhGWrmZG4xYQMsRrE